### PR TITLE
Add support for Phraseapp branches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,11 @@
             <version>5.1.2.RELEASE</version>
         </dependency>
 
-
+        <dependency>
+            <groupId>org.aeonbits.owner</groupId>
+            <artifactId>owner</artifactId>
+            <version>1.0.10</version>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApi.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApi.kt
@@ -53,6 +53,11 @@ interface PhraseApi {
     @RequestLine("GET /api/v2/projects/{projectId}/locales")
     fun locales(@Param("projectId") projectId: String): Response
 
+    @RequestLine("GET /api/v2/projects/{projectId}/locales?branch={branch}")
+    fun branchLocales(
+        @Param("projectId") projectId: String,
+        @Param("branch") branch: String): Response
+
     @RequestLine("POST /api/v2/projects/{projectId}/locales")
     fun createLocale(
         @Param("projectId") projectId: String,
@@ -84,33 +89,37 @@ interface PhraseApi {
         @Param("autotranslate")  autotranslate: String?
     ): Response
 
-    @RequestLine("GET /api/v2/projects/{projectId}/locales/{localeId}")
+    @RequestLine("GET /api/v2/projects/{projectId}/locales/{localeId}?branch={branch}")
     fun locale(
         @Param("projectId") projectId: String,
-        @Param("localeId") localeId: String
+        @Param("localeId") localeId: String,
+        @Param("branch") branch: String? = null
     ): Response
 
-    @RequestLine("DELETE /api/v2/projects/{projectId}/locales/{localeId}")
+    @RequestLine("DELETE /api/v2/projects/{projectId}/locales/{localeId}?branch={branch}")
     fun deleteLocale(
         @Param("projectId") projectId: String,
-        @Param("localeId") localeId: String
+        @Param("localeId") localeId: String,
+        @Param("branch") branch: String? = null
     ): Response
 
-    @RequestLine("GET /api/v2/projects/{projectId}/locales/{localeId}/download?file_format={fileFormat}" +
-        "&format_options[escape_single_quotes]={escapeSingleQuotes}")
+    @RequestLine("GET /api/v2/projects/{projectId}/locales/{localeId}/download?branch={branch}" +
+            "&file_format={fileFormat}" +
+            "&format_options[escape_single_quotes]={escapeSingleQuotes}")
     fun downloadLocale(
         @Param("projectId") projectId: String,
         @Param("localeId") localeId: String,
         @Param("fileFormat") fileFormat: String,
-        @Param("escapeSingleQuotes") escapeSingleQuotes: Boolean? = false
+        @Param("escapeSingleQuotes") escapeSingleQuotes: Boolean? = false,
+        @Param("branch") branch: String? = null
     ): Response
 
-
     //Translations
-    @RequestLine("GET /api/v2/projects/{projectId}/locales/{localeId}/translations")
+    @RequestLine("GET /api/v2/projects/{projectId}/locales/{localeId}/translations?branch={branch}")
     fun translations(
         @Param("projectId") projectId: String,
-        @Param("localeId") localeId: String
+        @Param("localeId") localeId: String,
+        @Param("branch") branch: String? = null
     ): Response
 
     @RequestLine("POST /api/v2/projects/{project_id}/translations")
@@ -118,7 +127,8 @@ interface PhraseApi {
         @Param("project_id") projectId: String,
         @Param("locale_id") localeId: String,
         @Param("key_id") keyId: String,
-        @Param("content") content: String
+        @Param("content") content: String,
+        @Param("branch") branch: String? = null
     ): Response
 
 
@@ -147,6 +157,7 @@ interface PhraseApi {
     fun createKey(
         @Param("project_id") projectId: String,
         @Param("name") name: String,
+        @Param("branch") branch: String? = null,
         @Param("tags") tags: ArrayList<String>? = null
     ): Response
 
@@ -154,13 +165,15 @@ interface PhraseApi {
     fun searchKey(
         @Param("project_id") projectId: String,
         @Param("locale_id") localeId: String?,
-        @Param("q") q: String? = null
+        @Param("q") q: String? = null,
+        @Param("branch") branch: String? = null
     ): Response
 
     @RequestLine("DELETE /api/v2/projects/{projectId}/keys/{keyId}")
     fun deleteKey(
         @Param("projectId") projectId: String,
-        @Param("keyId") keyId: String
+        @Param("keyId") keyId: String,
+        @Param("branch") branch: String? = null
     ): Response
 
 }

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApi.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApi.kt
@@ -50,13 +50,9 @@ interface PhraseApi {
     fun deleteProject(@Param("projectId") projectId: String): Response
 
     //Locales
-    @RequestLine("GET /api/v2/projects/{projectId}/locales")
-    fun locales(@Param("projectId") projectId: String): Response
-
     @RequestLine("GET /api/v2/projects/{projectId}/locales?branch={branch}")
-    fun branchLocales(
-        @Param("projectId") projectId: String,
-        @Param("branch") branch: String): Response
+    fun locales(@Param("projectId") projectId: String,
+                @Param("branch") branch: String? = null): Response
 
     @RequestLine("POST /api/v2/projects/{projectId}/locales")
     fun createLocale(

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClient.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClient.kt
@@ -28,13 +28,9 @@ interface PhraseApiClient {
 
     fun updateProject(projectId: String, phraseProject: UpdatePhraseProject): PhraseProject?
 
-    fun locales(projectId: String, localeId: String): PhraseLocale?
+    fun locale(projectId: String, localeId: String, branch: String? = null): PhraseLocale?
 
-    fun locale(projectId: String, localeId: String, branch: String): PhraseLocale?
-
-    fun locales(projectId: String): PhraseLocales?
-
-    fun branchLocales(projectId: String, branch: String): PhraseLocales?
+    fun locales(projectId: String, branch: String? = null): PhraseLocales?
 
     fun createLocale(projectId: String, locale: CreatePhraseLocale): PhraseLocale?
 

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClient.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClient.kt
@@ -30,28 +30,35 @@ interface PhraseApiClient {
 
     fun locales(projectId: String, localeId: String): PhraseLocale?
 
+    fun locale(projectId: String, localeId: String, branch: String): PhraseLocale?
+
     fun locales(projectId: String): PhraseLocales?
+
+    fun branchLocales(projectId: String, branch: String): PhraseLocales?
 
     fun createLocale(projectId: String, locale: CreatePhraseLocale): PhraseLocale?
 
-    fun downloadLocale(projectId: String, localeId: String): PhraseLocaleMessages?
+    fun downloadLocale(projectId: String, localeId: String, branch: String? = null): PhraseLocaleMessages?
 
-    fun downloadLocaleAsProperties(projectId: String, localeId: String, escapeSingleQuotes: Boolean): ByteArray?
+    fun downloadLocaleAsProperties(projectId: String, localeId: String,
+                                   escapeSingleQuotes: Boolean, branch: String? = null): ByteArray?
 
-    fun deleteLocale(projectId: String, localeId: String)
+    fun deleteLocale(projectId: String, localeId: String, branch: String? = null)
 
-    fun translations(project: PhraseProject, locale: PhraseLocale): Translations?
+    fun translations(project: PhraseProject, locale: PhraseLocale, branch: String? = null): Translations?
 
     fun createTranslation(projectId: String, createTranslation: CreateTranslation): Translation?
 
-    fun createTranslation(projectId: String, localeId: String, keyId: String, content: String): Translation?
+    fun createTranslation(projectId: String, localeId: String,
+                          keyId: String, content: String,
+                          branch: String? = null): Translation?
 
     fun createKey(project: String, createKey: CreateKey): Key?
 
-    fun createKey(project: String, name: String, tags: ArrayList<String>?): Key?
+    fun createKey(project: String, name: String, tags: ArrayList<String>?, branch: String? = null): Key?
 
-    fun searchKey(projectId: String, localeId: String?, q: String?): Keys?
+    fun searchKey(projectId: String, localeId: String?, q: String?, branch: String? = null): Keys?
 
-    fun deleteKey(projectId: String, keyId: String): Boolean
+    fun deleteKey(projectId: String, keyId: String, branch: String? = null): Boolean
 
 }

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientImpl.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientImpl.kt
@@ -128,27 +128,15 @@ class PhraseApiClientImpl : PhraseApiClient {
         return processResponse("PUT/api/v2/projects/$projectId", response)
     }
 
-    override fun locales(projectId: String, localeId: String): PhraseLocale? {
-        log.debug("Get locale [$localeId] for master branch of project [$projectId]")
-        val response = client.locale(projectId, localeId)
-        return processResponse("GET/api/v2/projects/$projectId/locales/$localeId", response)
-    }
-
-    override fun locale(projectId: String, localeId: String, branch: String): PhraseLocale? {
+    override fun locale(projectId: String, localeId: String, branch: String?): PhraseLocale? {
         log.debug("Get locale [$localeId] for the [$branch] branch of project [$projectId]")
         val response = client.locale(projectId, localeId, branch)
         return processResponse("GET/api/v2/projects/$projectId/locales/$localeId?branch=$branch", response)
     }
 
-    override fun locales(projectId: String): PhraseLocales? {
-        log.debug("Get locales for the master branch of the project [$projectId]")
-        val response = client.locales(projectId)
-        return processResponse("GET/api/v2/projects/$projectId/locales", response)
-    }
-
-    override fun branchLocales(projectId: String, branch: String): PhraseLocales? {
+    override fun locales(projectId: String, branch: String?): PhraseLocales? {
         log.debug("Get locales for the [$branch] branch of project [$projectId]")
-        val response = client.branchLocales(projectId, branch)
+        val response = client.locales(projectId, branch)
         return processResponse("GET/api/v2/projects/$projectId/locales?branch=$branch", response)
     }
 
@@ -416,9 +404,7 @@ class PhraseApiClientImpl : PhraseApiClient {
 
 
         //LOCALE
-        override fun locales(projectId: String): Response = target.locales(projectId)
-
-        override fun branchLocales(projectId: String, branch: String): Response = target.branchLocales(projectId, branch)
+        override fun locales(projectId: String, branch: String?): Response = target.locales(projectId, branch)
 
         override fun locale(projectId: String, localeId: String, branch: String?): Response = target.locale(projectId, localeId, branch)
 

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientImpl.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientImpl.kt
@@ -129,15 +129,27 @@ class PhraseApiClientImpl : PhraseApiClient {
     }
 
     override fun locales(projectId: String, localeId: String): PhraseLocale? {
-        log.debug("Get locale [$localeId] for project [$projectId]")
+        log.debug("Get locale [$localeId] for master branch of project [$projectId]")
         val response = client.locale(projectId, localeId)
         return processResponse("GET/api/v2/projects/$projectId/locales/$localeId", response)
     }
 
+    override fun locale(projectId: String, localeId: String, branch: String): PhraseLocale? {
+        log.debug("Get locale [$localeId] for the [$branch] branch of project [$projectId]")
+        val response = client.locale(projectId, localeId, branch)
+        return processResponse("GET/api/v2/projects/$projectId/locales/$localeId?branch=$branch", response)
+    }
+
     override fun locales(projectId: String): PhraseLocales? {
-        log.debug("Get locales for project [$projectId]")
+        log.debug("Get locales for the master branch of the project [$projectId]")
         val response = client.locales(projectId)
         return processResponse("GET/api/v2/projects/$projectId/locales", response)
+    }
+
+    override fun branchLocales(projectId: String, branch: String): PhraseLocales? {
+        log.debug("Get locales for the [$branch] branch of project [$projectId]")
+        val response = client.branchLocales(projectId, branch)
+        return processResponse("GET/api/v2/projects/$projectId/locales?branch=$branch", response)
     }
 
     override fun createLocale(projectId: String, locale: CreatePhraseLocale): PhraseLocale? {
@@ -146,7 +158,7 @@ class PhraseApiClientImpl : PhraseApiClient {
             projectId,
             locale.name,
             locale.code,
-            null,
+            locale.branch,
             locale.default,
             locale.mail,
             locale.rtl,
@@ -158,45 +170,52 @@ class PhraseApiClientImpl : PhraseApiClient {
         return processResponse("POST/api/v2/projects/$projectId/locales", response)
     }
 
-    override fun downloadLocale(projectId: String, localeId: String): PhraseLocaleMessages? {
-        log.debug("Download locale [$localeId] for project [$projectId]")
-        val response = client.downloadLocale(projectId, localeId, "json")
-        return processResponse("GET/api/v2/projects/$projectId/locales/$localeId/download?file_format=json", response)
+    override fun downloadLocale(projectId: String, localeId: String, branch: String?): PhraseLocaleMessages? {
+        log.debug("Download locale [$localeId] for [${processBranchNameForLog(branch)}] branch of project [$projectId]")
+        val response = client.downloadLocale(projectId, localeId, "json", branch = branch)
+        return processResponse("GET/api/v2/projects/$projectId/locales/$localeId/download?file_format=json?branch={branch}", response)
     }
 
-    override fun downloadLocaleAsProperties(projectId: String, localeId: String, escapeSingleQuotes: Boolean): ByteArray? {
-        log.debug("Download locale [$localeId] for project [$projectId]")
-        val response = client.downloadLocale(projectId, localeId, "properties", escapeSingleQuotes)
-        return processResponse("GET/api/v2/projects/$projectId/locales/$localeId/download?file_format=json", response)
+    override fun downloadLocaleAsProperties(projectId: String, localeId: String, escapeSingleQuotes: Boolean, branch: String?): ByteArray? {
+        log.debug("Download locale [$localeId] for [${processBranchNameForLog(branch)}] branch of project [$projectId]")
+        val response = client.downloadLocale(projectId, localeId, "properties", escapeSingleQuotes, branch)
+        return processResponse("GET/api/v2/projects/$projectId/locales/$localeId/download?branch=$branch&file_format=json", response)
     }
 
-    override fun deleteLocale(projectId: String, localeId: String) {
-        log.debug("Delete locale [$localeId] for project [$projectId]")
-        client.deleteLocale(projectId, localeId)
+    override fun deleteLocale(projectId: String, localeId: String, branch: String?) {
+        log.debug("Delete locale [$localeId] for [${processBranchNameForLog(branch)}] branch of project [$projectId]")
+        client.deleteLocale(projectId, localeId, branch)
     }
 
-    override fun translations(project: PhraseProject, locale: PhraseLocale): Translations? {
-        log.debug("Get translations for locale [${locale.id}] for project [${project.id}]")
-        val response = client.translations(project.id, locale.id)
-        return processResponse("GET/api/v2/projects/${project.id}/locales/${locale.id}/translations", response)
+    override fun translations(project: PhraseProject, locale: PhraseLocale, branch: String?): Translations? {
+        log.debug("Get translations for locale [${locale.id}] for " +
+                "[${processBranchNameForLog(branch)}] branch of " +
+                "project [${project.id}]")
+        val response = client.translations(project.id, locale.id, branch)
+        return processResponse("GET/api/v2/projects/${project.id}/locales/${locale.id}/translations?branch=$branch", response)
     }
 
     override fun createTranslation(projectId: String, createTranslation: CreateTranslation): Translation? {
-        log.debug("Creating the translation [${createTranslation.content}] for locale [${createTranslation.localeId}] " +
-            "for project [$projectId] for key [${createTranslation.keyId}]")
-        val response = client.createTranslation(projectId, createTranslation.localeId, createTranslation.keyId, createTranslation.content)
+        log.debug("Creating the translation [${createTranslation.content}] for " +
+                "locale [${createTranslation.localeId}] for " +
+                "project [$projectId] for " +
+                "key [${createTranslation.keyId}] for " +
+                "branch [${processBranchNameForLog(createTranslation.branch)}]")
+        val response = client.createTranslation(projectId, createTranslation.localeId, createTranslation.keyId, createTranslation.content, createTranslation.branch)
         return processResponse("POST/api/v2/projects/$projectId/translations", response)
     }
 
-    override fun createTranslation(projectId: String, localeId: String, keyId: String, content: String): Translation? {
+    override fun createTranslation(projectId: String, localeId: String, keyId: String, content: String, branch: String?): Translation? {
         log.debug("Creating the translation [$content] for locale [$localeId] " +
-                "for project [$projectId] for key [$keyId]")
-        val response = client.createTranslation(projectId, localeId, keyId, content)
+                "for project [$projectId] for key [$keyId] for branch [${processBranchNameForLog(branch)}]")
+        val response = client.createTranslation(projectId, localeId, keyId, content, branch)
         return processResponse("POST/api/v2/projects/$projectId/translations", response)
     }
 
     override fun createKey(projectId: String, createKey: CreateKey): Key? {
-        log.debug("Creating keys [${createKey.name}] for project [$projectId]")
+        log.debug("Creating keys [${createKey.name}] for " +
+                "[${processBranchNameForLog(createKey.branch)}] branch of " +
+                "project [$projectId]")
         val response = client.createKey(
             projectId,
             createKey.name,
@@ -218,23 +237,26 @@ class PhraseApiClientImpl : PhraseApiClient {
         return processResponse("POST/api/v2/projects/$projectId/keys", response)
     }
 
-    override fun createKey(projectId: String, name: String, tags: ArrayList<String>?): Key? {
-        log.debug("Creating keys [$name] for project [$projectId]")
-        val response = client.createKey(projectId, name, tags)
+    override fun createKey(projectId: String, name: String, tags: ArrayList<String>?, branch: String?): Key? {
+        log.debug("Creating keys [$name] for [${processBranchNameForLog(branch)}] branch of project [$projectId]")
+        val response = client.createKey(projectId, name, branch, tags)
         return processResponse("POST/api/v2/projects/$projectId/keys", response)
     }
 
-
-    override fun searchKey(projectId: String, localeId: String?, q: String?): Keys? {
-        log.debug("Searching keys for project [$projectId] - locale [$localeId] - query [$q]")
-        val response = client.searchKey(projectId, localeId, q)
+    override fun searchKey(projectId: String, localeId: String?, q: String?, branch: String?): Keys? {
+        log.debug("Searching keys for " +
+                "[${processBranchNameForLog(branch)}] branch of " +
+                "project [$projectId] - " +
+                "locale [$localeId] - " +
+                "query [$q]")
+        val response = client.searchKey(projectId, localeId, q, branch)
         return processResponse("POST/api/v2/projects/$projectId/keys/search", response)
     }
 
-    override fun deleteKey(projectId: String, keyId: String): Boolean {
-        log.debug("Deleting key [$keyId] for project [$projectId]")
-        val response = client.deleteKey(projectId, keyId)
-        processResponse<Void>("DELETE/api/v2/projects/$projectId/keys/$keyId", response)
+    override fun deleteKey(projectId: String, keyId: String, branch: String?): Boolean {
+        log.debug("Deleting key [$keyId] for [${processBranchNameForLog(branch)}] branch of project [$projectId]")
+        val response = client.deleteKey(projectId, keyId, branch)
+        //processResponse<Void>("DELETE/api/v2/projects/$projectId/keys/$keyId", response)
         return response.status() == HttpStatus.SC_NO_CONTENT
     }
 
@@ -307,6 +329,8 @@ class PhraseApiClientImpl : PhraseApiClient {
             .find { it.key.equals(HttpHeaders.ETAG, true) }
         return eTagHeader?.value?.first()
     }
+
+    private fun processBranchNameForLog(branch: String?) = if (branch.isNullOrBlank()) "master" else branch
 
     @Suppress("TooManyFunctions")
     private class PhraseApiImpl(
@@ -394,10 +418,12 @@ class PhraseApiClientImpl : PhraseApiClient {
         //LOCALE
         override fun locales(projectId: String): Response = target.locales(projectId)
 
-        override fun locale(projectId: String, localeId: String): Response = target.locale(projectId, localeId)
+        override fun branchLocales(projectId: String, branch: String): Response = target.branchLocales(projectId, branch)
 
-        override fun downloadLocale(projectId: String, localeId: String, fileFormat: String, escapeSingleQuotes: Boolean?):
-            Response = target.downloadLocale(projectId, localeId, fileFormat, escapeSingleQuotes)
+        override fun locale(projectId: String, localeId: String, branch: String?): Response = target.locale(projectId, localeId, branch)
+
+        override fun downloadLocale(projectId: String, localeId: String, fileFormat: String, escapeSingleQuotes: Boolean?, branch: String?):
+            Response = target.downloadLocale(projectId, localeId, fileFormat, escapeSingleQuotes, branch)
 
         override fun createLocale(
             projectId: String,
@@ -428,13 +454,14 @@ class PhraseApiClientImpl : PhraseApiClient {
             autotranslate: String?
         ): Response = target.updateLocale(projectId, localeId, name, code, branch, default, mail, rtl, sourceLocaleId, unverifyNewTranslations, unverifyUpdatedTranslations, autotranslate)
 
-        override fun deleteLocale(projectId: String, localeId: String): Response = target.deleteLocale(projectId, localeId)
+        override fun deleteLocale(projectId: String, localeId: String, branch: String?): Response = target.deleteLocale(projectId, localeId, branch)
 
 
         //TRANSLATION
-        override fun translations(projectId: String, localeId: String): Response = target.translations(projectId, localeId)
+        override fun translations(projectId: String, localeId: String, branch: String?): Response = target.translations(projectId, localeId, branch)
 
-        override fun createTranslation(projectId: String, localeId: String, keyId: String, content: String): Response = target.createTranslation(projectId, localeId, keyId, content)
+        override fun createTranslation(projectId: String, localeId: String, keyId: String, content: String, branch: String?): Response = target.createTranslation(projectId,
+            localeId, keyId, content, branch)
 
 
         //KEYS
@@ -458,11 +485,11 @@ class PhraseApiClientImpl : PhraseApiClient {
         ): Response = target.createKey(projectId, name, tags, description, branch, plural, namePlural, dataType, maxCharactersAllowed, screenshot, removeScreenshot, unformatted,
             xmlSpacePreserve, originalFile, localizedFormatString, localizedFormatKey)
 
-        override fun createKey(projectId: String, name: String, tags: ArrayList<String>?): Response = target.createKey(projectId, name, tags)
+        override fun createKey(projectId: String, name: String, branch: String?, tags: ArrayList<String>?): Response = target.createKey(projectId, name, branch, tags)
 
-        override fun searchKey(projectId: String, localeId: String?, q: String?): Response = target.searchKey(projectId, localeId, q)
+        override fun searchKey(projectId: String, localeId: String?, q: String?, branch: String?): Response = target.searchKey(projectId, localeId, q, branch)
 
-        override fun deleteKey(projectId: String, keyId: String): Response = target.deleteKey(projectId, keyId)
+        override fun deleteKey(projectId: String, keyId: String, branch: String?): Response = target.deleteKey(projectId, keyId, branch)
     }
 }
 

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/client/model/PhraseLocale.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/client/model/PhraseLocale.kt
@@ -5,6 +5,7 @@ import java.util.Date
 data class CreatePhraseLocale(
     val name: String,
     val code: String,
+    val branch: String? = null,
     val default: Boolean? = null,
     val mail: Boolean? = null,
     val rtl: Boolean? = null,

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/task/PhraseAppSyncTask.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/task/PhraseAppSyncTask.kt
@@ -39,7 +39,7 @@ class PhraseAppSyncTask(
             log.debug("Phrase App sync started")
 
             config.branches.forEach { branch ->
-                client.branchLocales(config.projectId, branch)
+                client.locales(config.projectId, branch)
                     .orEmpty()
                     .forEach {
                         updateLocaleFile(it, branch)

--- a/src/main/kotlin/com/mytaxi/apis/phraseapi/task/PhraseAppSyncTask.kt
+++ b/src/main/kotlin/com/mytaxi/apis/phraseapi/task/PhraseAppSyncTask.kt
@@ -15,44 +15,57 @@ class PhraseAppSyncTask(
 ) : Runnable {
 
     private var log = LoggerFactory.getLogger(PhraseAppSyncTask::class.java.name)
-    private var messagesDirectory: Path
+    private var rootMessagesDirectory: Path
     private val client: PhraseApiClient
+
+    private val defaultBranch = "master"
 
     init {
         client = PhraseApiClientImpl(config.url, config.authKey)
 
         try {
             val classPathResource = ClassPathResource("/").file.path
-            messagesDirectory = Paths.get("$classPathResource/${config.messagesFolder}")
+            rootMessagesDirectory = Paths.get("$classPathResource")
         } catch (e: Exception) {
             log.error("could not get default ClassPathResource. use /generated-resources/ instead")
-            messagesDirectory = Paths.get(config.generatedResourcesFolder + config.messagesFolder)
+            rootMessagesDirectory = Paths.get(config.generatedResourcesFolder)
         }
 
-        Files.createDirectories(messagesDirectory)
+        Files.createDirectories(rootMessagesDirectory)
     }
 
     override fun run() {
         try {
             log.debug("Phrase App sync started")
-            client.locales(config.projectId)
-                .orEmpty()
-                .forEach {
-                    updateLocaleFile(it)
-                }
+
+            config.branches.forEach { branch ->
+                client.branchLocales(config.projectId, branch)
+                    .orEmpty()
+                    .forEach {
+                        updateLocaleFile(it, branch)
+                    }
+            }
             log.debug("Phrase App sync finished")
         } catch (ex: Exception) {
             log.warn("PhraseApp sync failed", ex)
         }
     }
 
-    private fun updateLocaleFile(locale: PhraseLocale) {
+
+    private fun handleBranchPath(branch: String): Path = when (defaultBranch == branch)
+    {
+        true -> rootMessagesDirectory.resolve(config.messagesFolder)
+        false -> rootMessagesDirectory.resolve("${config.messagesFolder}_$branch")
+    }
+
+    private fun updateLocaleFile(locale: PhraseLocale, branch: String) {
         try {
-            val byteArray = client.downloadLocaleAsProperties(config.projectId, locale.id, config.escapeSingleQuotes)
+            val byteArray = client.downloadLocaleAsProperties(config.projectId, locale.id, config.escapeSingleQuotes, branch)
             if (byteArray != null) {
                 val fileName = createFileName(locale.code)
-                val path = messagesDirectory.resolve(fileName)
+                val path = handleBranchPath(branch).resolve(fileName)
                 if (!Files.exists(path)) {
+                    Files.createDirectories(path.parent)
                     Files.createFile(path)
                 }
                 Files.write(path, byteArray)
@@ -71,8 +84,9 @@ data class PhraseAppSyncTaskConfig @JvmOverloads constructor(
     val url: String,
     val authKey: String,
     val projectId: String,
+    val branches: List<String> = listOf("master"),
     val generatedResourcesFolder: String = "generated-resources/",
-    val messagesFolder: String = "messages/",
+    val messagesFolder: String = "messages",
     val messagesFilePostfix: String = ".properties",
     val messagesFilePrefix: String = "messages_",
     val escapeSingleQuotes: Boolean = false

--- a/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientDownloadLocaleTest.kt
+++ b/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientDownloadLocaleTest.kt
@@ -142,7 +142,7 @@ class PhraseApiClientDownloadLocaleTest {
         expectedLocaleMessages[messageKey] = Message(message, description)
 
         val responseFirst = Response.create(
-           429,
+            429,
             "Not Ok",
             headers,
             "{\"message\":\"Rate limit exceeded\",\"documentation_url\":\"https://developers.phraseapp.com/api/#rate-limit\"}",

--- a/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientLocaleTest.kt
+++ b/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientLocaleTest.kt
@@ -56,7 +56,7 @@ class PhraseApiClientLocaleTest {
         on(client.locale(projectId, localeId)).thenReturn(response)
 
         //WHEN
-        val actualLocale = phraseApiClient.locales(projectId, localeId)
+        val actualLocale = phraseApiClient.locale(projectId, localeId)
 
         //THEN
         assertNotNull(actualLocale)

--- a/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientLocalesIntegrationTest.kt
+++ b/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientLocalesIntegrationTest.kt
@@ -1,0 +1,110 @@
+package com.mytaxi.apis.phraseapi.client
+
+import com.mytaxi.apis.phraseapi.client.config.TestConfig
+import com.mytaxi.apis.phraseapi.client.model.CreatePhraseLocale
+import org.aeonbits.owner.ConfigFactory
+import org.junit.Assume.assumeFalse
+import org.junit.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class PhraseApiClientLocalesIntegrationTest {
+
+    private val cfg = ConfigFactory.create(TestConfig::class.java, System.getenv(), System.getProperties())
+
+    private var phraseApiClient: PhraseApiClient
+    private var clientConfig: PhraseApiClientConfig
+    private var branch: String
+    private var projectId: String
+    private var localeIdDe: String
+    private var localeIdDeBranch: String
+
+
+    init {
+        //GIVEN
+        assumeFalse(System.getenv("TRAVIS")?.let { it.toBoolean() } ?: false)
+
+        assertNotNull(cfg.authToken())
+        assertNotNull(cfg.host())
+
+        clientConfig = PhraseApiClientConfig(cfg.host(), cfg.authToken())
+        phraseApiClient = PhraseApiClientImpl(clientConfig)
+        projectId = cfg.projectId()
+        branch = cfg.branch()
+        localeIdDe = cfg.localeIdDe()
+        localeIdDeBranch = cfg.localeIdDeBranch()
+    }
+
+
+    @Test
+    fun `Should list locales`() {
+
+        //WHEN
+        val masterLocales = phraseApiClient.locales(projectId)
+        val branchLocales = phraseApiClient.branchLocales(projectId, branch)
+
+        //THEN
+        assertNotNull(masterLocales)
+        assertNotNull(branchLocales)
+    }
+
+    @Test
+    fun `Should retrieve a locale`() {
+
+        //WHEN
+        val masterLocale = phraseApiClient.locales(projectId, localeIdDe)
+        val branchLocale = phraseApiClient.locale(projectId, localeIdDeBranch, branch)
+
+        //THEN
+        assertNotNull(masterLocale)
+        assertNotNull(masterLocale!!.id)
+        assertNotNull(branchLocale)
+        assertNotNull(branchLocale!!.id)
+    }
+
+    @Test
+    fun `Should download locale`() {
+
+        //WHEN
+        val masterLocaleMessages = phraseApiClient.downloadLocale(projectId, localeIdDe)
+        val branchLocaleMessages = phraseApiClient.downloadLocale(projectId, localeIdDeBranch, branch)
+
+        //THEN
+        assertNotNull(branchLocaleMessages)
+        assertNotNull(masterLocaleMessages)
+    }
+
+    @Test
+    fun `Should download locale as properties`() {
+
+        //WHEN
+        val masterLocales = phraseApiClient.downloadLocaleAsProperties(projectId, localeIdDe, true)
+        val branchLocales = phraseApiClient.downloadLocaleAsProperties(projectId, localeIdDeBranch, true, branch)
+
+        //THEN
+        assertNotNull(branchLocales)
+        assertNotNull(masterLocales)
+    }
+
+    @Test
+    fun `Should create and delete locales`() {
+
+        //GIVEN
+        val masterLocale = phraseApiClient.createLocale(projectId, CreatePhraseLocale("es", "es-ES"))
+        val branchLocale = phraseApiClient.createLocale(projectId, CreatePhraseLocale("es", "es-ES", branch))
+
+        //AND
+        assertNotNull(masterLocale)
+        assertNotNull(masterLocale!!.id)
+        assertNotNull(branchLocale)
+        assertNotNull(branchLocale!!.id)
+
+        //WHEN
+        phraseApiClient.deleteLocale(projectId, masterLocale.id)
+        phraseApiClient.deleteLocale(projectId, branchLocale.id, branch)
+
+        //THEN
+        assertFailsWith<PhraseAppApiException> { phraseApiClient.locales(projectId, masterLocale.id) }
+        assertFailsWith<PhraseAppApiException> { phraseApiClient.locale(projectId, masterLocale.id, branch) }
+    }
+}

--- a/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientLocalesIntegrationTest.kt
+++ b/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientLocalesIntegrationTest.kt
@@ -4,10 +4,12 @@ import com.mytaxi.apis.phraseapi.client.config.TestConfig
 import com.mytaxi.apis.phraseapi.client.model.CreatePhraseLocale
 import org.aeonbits.owner.ConfigFactory
 import org.junit.Assume.assumeFalse
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
+@Ignore
 class PhraseApiClientLocalesIntegrationTest {
 
     private val cfg = ConfigFactory.create(TestConfig::class.java, System.getenv(), System.getProperties())
@@ -41,7 +43,7 @@ class PhraseApiClientLocalesIntegrationTest {
 
         //WHEN
         val masterLocales = phraseApiClient.locales(projectId)
-        val branchLocales = phraseApiClient.branchLocales(projectId, branch)
+        val branchLocales = phraseApiClient.locales(projectId, branch)
 
         //THEN
         assertNotNull(masterLocales)
@@ -52,7 +54,7 @@ class PhraseApiClientLocalesIntegrationTest {
     fun `Should retrieve a locale`() {
 
         //WHEN
-        val masterLocale = phraseApiClient.locales(projectId, localeIdDe)
+        val masterLocale = phraseApiClient.locale(projectId, localeIdDe)
         val branchLocale = phraseApiClient.locale(projectId, localeIdDeBranch, branch)
 
         //THEN

--- a/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientTranslationsKeysIntegrationTest.kt
+++ b/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientTranslationsKeysIntegrationTest.kt
@@ -1,0 +1,129 @@
+package com.mytaxi.apis.phraseapi.client
+
+import com.mytaxi.apis.phraseapi.client.config.TestConfig
+import com.mytaxi.apis.phraseapi.client.model.PhraseLocale
+import com.mytaxi.apis.phraseapi.client.model.PhraseProject
+import com.mytaxi.apis.phraseapi.client.model.Key
+import org.aeonbits.owner.ConfigFactory
+import org.junit.Assume.assumeFalse
+import org.junit.Test
+import kotlin.test.*
+
+class PhraseApiClientTranslationsKeysIntegrationTest {
+
+    private val cfg = ConfigFactory.create(TestConfig::class.java, System.getenv(), System.getProperties())
+    private val localeCode = "de-DE"
+    private val localeName = "de"
+    private val projectName = "TestProject"
+
+    private var phraseApiClient: PhraseApiClient
+    private var clientConfig: PhraseApiClientConfig
+    private var branch: String
+    private var projectId: String
+    private var localeIdDe: String
+    private var localeIdDeBranch: String
+
+
+    init {
+        //GIVEN
+        assumeFalse(System.getenv("TRAVIS")?.let { it.toBoolean() } ?: false)
+
+        assertNotNull(cfg.authToken())
+        assertNotNull(cfg.host())
+
+        clientConfig = PhraseApiClientConfig(cfg.host(), cfg.authToken())
+        phraseApiClient = PhraseApiClientImpl(clientConfig)
+        projectId = cfg.projectId()
+        branch = cfg.branch()
+        localeIdDe = cfg.localeIdDe()
+        localeIdDeBranch = cfg.localeIdDeBranch()
+    }
+
+
+    @Test
+    fun `Should list translations`() {
+
+        //WHEN
+        val masterTranslations = phraseApiClient.translations(
+            PhraseProject(projectId, projectName),
+            PhraseLocale(localeIdDe, localeName, localeCode))
+
+        val branchTranslations = phraseApiClient.translations(
+            PhraseProject(projectId, projectName),
+            PhraseLocale(localeIdDeBranch, localeName, localeCode),
+            branch)
+
+        //THEN
+        assertNotNull(branchTranslations)
+        assertNotNull(masterTranslations)
+        assertNotEquals(branchTranslations?.get(0)?.id, masterTranslations?.get(0)?.id)
+    }
+
+
+    @Test
+    fun `Should create keys and translations`() {
+
+        //GIVEN
+        val masterKey: Key? = phraseApiClient.createKey(projectId, "testKeyForTranslation", null)
+        val branchKey: Key? = phraseApiClient.createKey(projectId, "branchTestKeyForTranslation", null, branch)
+
+        //AND
+        assertNotNull(masterKey)
+        assertNotNull(masterKey!!.id)
+        assertNotNull(branchKey)
+        assertNotNull(branchKey!!.id)
+
+        //WHEN
+        val branchTranslation = phraseApiClient.createTranslation(projectId, localeIdDeBranch, branchKey.id ,  "test translation", branch)
+        val masterTranslation = phraseApiClient.createTranslation(projectId, localeIdDe, masterKey.id ,  "test translation")
+
+        //THEN
+        assertNotNull(masterTranslation)
+        assertNotNull(masterTranslation!!.id)
+        assertNotNull(branchTranslation)
+        assertNotNull(branchTranslation!!.id)
+
+        //CLEAN UP
+        phraseApiClient.deleteKey(projectId, masterKey.id)
+        phraseApiClient.deleteKey(projectId, branchKey.id, branch)
+    }
+
+
+    @Test
+    fun `Should create and delete keys`() {
+
+        //GIVEN
+        val masterKey: Key? = phraseApiClient.createKey(projectId, "testKey", null)
+        val branchKey: Key? = phraseApiClient.createKey(projectId, "branchTestKey", null, branch)
+
+        //AND
+        assertNotNull(masterKey)
+        assertNotNull(masterKey!!.id)
+        assertNotNull(branchKey)
+        assertNotNull(branchKey!!.id)
+
+        //WHEN
+        val masterResponse = phraseApiClient.deleteKey(projectId, masterKey.id)
+        val branchResponse = phraseApiClient.deleteKey(projectId, branchKey.id, branch)
+
+        //THEN
+        assert(masterResponse)
+        assert(branchResponse)
+    }
+
+
+    @Test
+    fun `Should search for keys`() {
+
+        //WHEN
+        val masterKeys = phraseApiClient.searchKey(projectId, localeIdDe, null)
+        val masterKeysSize = masterKeys?.size ?: 0
+
+        val branchKeys = phraseApiClient.searchKey(projectId, localeIdDeBranch, null, branch)
+        val branchKeysSize = branchKeys?.size ?: 0
+
+        //THEN
+        assert(masterKeysSize > 0)
+        assert(branchKeysSize > 0)
+    }
+}

--- a/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientTranslationsKeysIntegrationTest.kt
+++ b/src/test/kotlin/com/mytaxi/apis/phraseapi/client/PhraseApiClientTranslationsKeysIntegrationTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assume.assumeFalse
 import org.junit.Test
 import kotlin.test.*
 
+@Ignore
 class PhraseApiClientTranslationsKeysIntegrationTest {
 
     private val cfg = ConfigFactory.create(TestConfig::class.java, System.getenv(), System.getProperties())

--- a/src/test/kotlin/com/mytaxi/apis/phraseapi/client/config/TestConfig.java
+++ b/src/test/kotlin/com/mytaxi/apis/phraseapi/client/config/TestConfig.java
@@ -1,0 +1,24 @@
+package com.mytaxi.apis.phraseapi.client.config;
+
+import org.aeonbits.owner.Config;
+
+public interface TestConfig extends Config
+{
+    @DefaultValue("${ENV_PHRASE_AUTHTOKEN}")
+    String authToken();
+
+    @DefaultValue("${ENV_PHRASE_PROJECTID}")
+    String projectId();
+
+    @DefaultValue("${ENV_PHRASE_BRANCH}")
+    String branch();
+
+    @DefaultValue("${ENV_PHRASE_LOCALEID_DE}")
+    String localeIdDe();
+
+    @DefaultValue("${ENV_PHRASE_LOCALEID_DE_BRANCH}")
+    String localeIdDeBranch();
+
+    @DefaultValue("${ENV_PHRASE_HOST}")
+    String host();
+}


### PR DESCRIPTION
Background
==========
As of now, the client does not provide any way to interact with Phraseapp branches and thus the users are stuck with the default, master branch.

Goal
====
The goal is to add support for working with the branches to the endpoints the client is already exposing.