### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -25,6 +25,8 @@ jobs:
           java-version: 8
           distribution: adopt
       - run: mvn -B verify -Dgpg.skip=true
+      - name: Upload test coverage
+        uses: codecov/codecov-action@v2
 
   release:
     if: github.ref == 'refs/heads/master'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 script:
-  - mvn clean verify
+  - mvn clean verify -q -Dgpg.skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-dist: trusty
-language: kotlin
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
-script:
-  - mvn clean verify -q -Dgpg.skip

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@ Kotlin Client for PhraseApp
 ## What is this?
 This project contains the task to handle the synchronization via API from [PhraseApp API v2](http://docs.phraseapp.com/api/v2/).
 
-[![Build Status][travis-image]][travis-url-main]
 [![codecov][codecov-badge-url]][codecov-project-url]
+[![Build](https://github.com/freenowtech/phrase-kotlin-client/actions/workflows/mvn.yml/badge.svg?branch=master)](https://github.com/freenowtech/phrase-kotlin-client/actions/workflows/mvn.yml)
+[![Release](https://img.shields.io/github/v/release/freenowtech/phrase-kotlin-client)](https://github.com/freenowtech/phrase-kotlin-client/releases/latest)
 
-[travis-image]: https://travis-ci.org/freenowtech/phrase-kotlin-client.svg?branch=master
-[travis-url-main]: https://travis-ci.org/freenowtech/phrase-kotlin-client
 [codecov-project-url]: https://codecov.io/gh/freenowtech/phrase-kotlin-client
 [codecov-badge-url]: https://codecov.io/gh/freenowtech/phrase-kotlin-client/branch/master/graph/badge.svg
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.free-now.apis</groupId>
     <artifactId>phrase-kotlin-client</artifactId>
-    <version>1.3.2.TEST-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>phrase-api-kotlin</name>
     <packaging>jar</packaging>
 
@@ -129,7 +129,7 @@
     <scm>
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.connection}</developerConnection>
-        <tag>phrase-kotlin-client-1.0.0</tag>
+        <tag>HEAD</tag>
         <url>${scm.url}</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.freenow.apis</groupId>
+    <groupId>com.free-now.apis</groupId>
     <artifactId>phrase-kotlin-client</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2.TEST-SNAPSHOT</version>
     <name>phrase-api-kotlin</name>
     <packaging>jar</packaging>
 
@@ -41,6 +41,7 @@
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <dokka.version>1.6.10</dokka.version>
     </properties>
 
     <dependencies>
@@ -152,7 +153,6 @@
             <name>bintray-plugins</name>
             <url>https://dl.bintray.com/ozsie/maven</url>
         </pluginRepository>
-
     </pluginRepositories>
 
     <build>
@@ -190,14 +190,16 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka.version}</version>
                 <executions>
                     <execution>
-                        <id>attach-javadocs</id>
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>dokka</goal>
+                            <goal>javadoc</goal>
+                            <goal>javadocJar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
# Background
In a previous release , github actions were included to perform the build and deploy to mvn central. 

# Problem
The project uses Kotlin , and the default mvn plugin that includes the javadoc does not work with this language. 
Besides , having the javadoc is a mandatory  stop to perform a release in the mvn central 

# Goal
* Include Dokka plugin and required configuration to attach javadoc in the packaged code

# Notes
When releasing with `github-actions-maven-release`  to `https://s01.oss.sonatype.org`  , it tries to assign a profile to the group id. Somehow we already have defined a profile for groupIds matching the pattern `com.free-now.XXX`. That's why the group id has changed. Otherwise the release step fails

As a result of that , I also decided to assign the version as 1.0.0 again. It should be ok as the group id is now different, and the project was not precisely in a very stable state