### PR TITLE
update versions openfeign, gson, spring-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.free-now.apis</groupId>
     <artifactId>phrase-kotlin-client</artifactId>
-    <version>1.3.6-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <name>phrase-api-kotlin</name>
     <packaging>jar</packaging>
 
@@ -33,9 +33,11 @@
         <java.version>1.8</java.version>
         <scm.connection>scm:git:git@github.com:freenowtech/phrase-kotlin-client.git</scm.connection>
         <scm.url>https://github.com/freenowtech/phrase-kotlin-client</scm.url>
-        <kotlin.version>1.3.61</kotlin.version>
+        <kotlin.version>1.7.10</kotlin.version>
 
-        <feign.version>8.18.0</feign.version>
+        <feign.version>11.9.1</feign.version>
+        <gson.version>2.9.1</gson.version>
+        <spring.version>5.3.22</spring.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
@@ -54,12 +56,12 @@
 
         <!--Feign-->
         <dependency>
-            <groupId>com.netflix.feign</groupId>
+            <groupId>io.github.openfeign</groupId>
             <artifactId>feign-gson</artifactId>
             <version>${feign.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.netflix.feign</groupId>
+            <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
             <version>${feign.version}</version>
         </dependency>
@@ -73,12 +75,12 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>${gson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.0-jre</version>
+            <version>31.1-jre</version>
         </dependency>
 
         <!--Other-->
@@ -98,13 +100,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>2.13.0</version>
+            <version>4.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.aeonbits.owner</groupId>
             <artifactId>owner</artifactId>
-            <version>1.0.10</version>
+            <version>1.0.12</version>
             <scope>test</scope>
         </dependency>
 
@@ -112,17 +114,17 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.2.22.RELEASE</version>
+            <version>${spring.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/test/kotlin/com/freenow/apis/phraseapi/client/FeignUtil.kt
+++ b/src/test/kotlin/com/freenow/apis/phraseapi/client/FeignUtil.kt
@@ -1,0 +1,32 @@
+package com.freenow.apis.phraseapi.client
+
+import feign.Request
+import feign.RequestTemplate
+import feign.Response
+import java.nio.charset.Charset
+
+object FeignUtil {
+
+    fun create(
+        status: Int, reason: String, headers: Map<String, List<String>>, body: String?, charset: Charset
+    ): Response {
+
+        return Response.builder()
+            .status(status)
+            .reason(reason)
+            .headers(headers)
+            .request(Request.create(Request.HttpMethod.GET, "", emptyMap(), null, RequestTemplate()))
+            .body(body, charset).build()
+    }
+
+    fun create(
+        status: Int, reason: String, headers: Map<String, List<String>>, body: ByteArray
+    ): Response {
+        return Response.builder()
+            .status(status)
+            .reason(reason)
+            .headers(headers)
+            .request(Request.create(Request.HttpMethod.GET, "", emptyMap(), null, RequestTemplate()))
+            .body(body).build()
+    }
+}

--- a/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientDownloadLocaleTest.kt
+++ b/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientDownloadLocaleTest.kt
@@ -6,7 +6,6 @@ import com.google.gson.Gson
 import com.freenow.apis.phraseapi.client.model.DownloadPhraseLocaleProperties
 import com.freenow.apis.phraseapi.client.model.Message
 import com.freenow.apis.phraseapi.client.model.PhraseLocaleMessages
-import feign.Response
 import org.apache.commons.httpclient.HttpStatus
 import org.junit.Test
 import org.mockito.Mockito.`when` as on
@@ -58,7 +57,7 @@ class PhraseApiClientDownloadLocaleTest {
         val projectsJSON = Gson().toJson(expectedLocaleMessages)
 
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_OK,
             "OK",
             headers,
@@ -100,7 +99,7 @@ class PhraseApiClientDownloadLocaleTest {
         val projectsJSON = Gson().toJson(expectedLocaleMessages)
 
 
-        val responseFirst = Response.create(
+        val responseFirst = FeignUtil.create(
             HttpStatus.SC_OK,
             "OK",
             headers,
@@ -112,7 +111,7 @@ class PhraseApiClientDownloadLocaleTest {
         val actualLocaleMessages = phraseApiClient.downloadLocale(projectId, localeId)
 
 
-        val responseSecond = Response.create(
+        val responseSecond = FeignUtil.create(
             HttpStatus.SC_NOT_MODIFIED,
             "OK",
             headers,
@@ -152,7 +151,7 @@ class PhraseApiClientDownloadLocaleTest {
         val expectedLocaleMessages = PhraseLocaleMessages()
         expectedLocaleMessages[messageKey] = Message(message, description)
 
-        val responseFirst = Response.create(
+        val responseFirst = FeignUtil.create(
             429,
             "Not Ok",
             headers,
@@ -179,7 +178,7 @@ class PhraseApiClientDownloadLocaleTest {
 
         val expectedLocaleMessages = "property = value".toByteArray()
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_OK,
             "OK",
             headers,
@@ -212,7 +211,7 @@ class PhraseApiClientDownloadLocaleTest {
         val expectedLocaleMessages = "property = value".toByteArray()
 
 
-        val responseFirst = Response.create(
+        val responseFirst = FeignUtil.create(
             HttpStatus.SC_OK,
             "OK",
             headers,
@@ -223,7 +222,7 @@ class PhraseApiClientDownloadLocaleTest {
         val actualLocaleMessages = phraseApiClient.downloadLocaleAsProperties(projectId, localeId, true)
 
 
-        val responseSecond = Response.create(
+        val responseSecond = FeignUtil.create(
             HttpStatus.SC_NOT_MODIFIED,
             "OK",
             headers,
@@ -256,7 +255,7 @@ class PhraseApiClientDownloadLocaleTest {
             HttpHeaders.CONTENT_TYPE to listOf(MediaType.OCTET_STREAM.toString())
         )
 
-        val responseFirst = Response.create(
+        val responseFirst = FeignUtil.create(
             429,
             "Not Ok",
             headers,

--- a/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientKeyTest.kt
+++ b/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientKeyTest.kt
@@ -6,7 +6,6 @@ import com.google.gson.Gson
 import com.freenow.apis.phraseapi.client.model.CreateKey
 import com.freenow.apis.phraseapi.client.model.Key
 import com.freenow.apis.phraseapi.client.model.Keys
-import feign.Response
 import org.apache.commons.httpclient.HttpStatus
 import org.junit.Test
 import org.mockito.Mockito.`when` as on
@@ -43,7 +42,7 @@ class PhraseApiClientKeyTest {
 
         val keyJSON = Gson().toJson(createKey)
 
-        val response = Response.create(HttpStatus.SC_CREATED, "OK", headers, keyJSON, StandardCharsets.UTF_8)
+        val response = FeignUtil.create(HttpStatus.SC_CREATED, "OK", headers, keyJSON, StandardCharsets.UTF_8)
 
         on(client.createKey(
             projectId = projectId,
@@ -81,7 +80,7 @@ class PhraseApiClientKeyTest {
 
         val keyJSON = Gson().toJson(expectedKey)
 
-        val response = Response.create(HttpStatus.SC_CREATED, "OK", headers, keyJSON, StandardCharsets.UTF_8)
+        val response = FeignUtil.create(HttpStatus.SC_CREATED, "OK", headers, keyJSON, StandardCharsets.UTF_8)
 
         on(client.createKey(projectId = projectId, name = keyName)).thenReturn(response)
 
@@ -114,7 +113,7 @@ class PhraseApiClientKeyTest {
 
         val keysJSON = Gson().toJson(keys)
 
-        val response = Response.create(HttpStatus.SC_OK, "OK", headers, keysJSON, StandardCharsets.UTF_8)
+        val response = FeignUtil.create(HttpStatus.SC_OK, "OK", headers, keysJSON, StandardCharsets.UTF_8)
 
         on(client.searchKey(projectId, localeId, q)).thenReturn(response)
 
@@ -139,7 +138,7 @@ class PhraseApiClientKeyTest {
             HttpHeaders.CONTENT_TYPE to listOf(JSON_UTF_8.toString())
         )
 
-        val response = Response.create(HttpStatus.SC_NO_CONTENT, "OK", headers, "{}", StandardCharsets.UTF_8)
+        val response = FeignUtil.create(HttpStatus.SC_NO_CONTENT, "OK", headers, "{}", StandardCharsets.UTF_8)
 
         on(client.deleteKey(projectId, keyId)).thenReturn(response)
 

--- a/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientLocaleTest.kt
+++ b/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientLocaleTest.kt
@@ -5,7 +5,6 @@ import com.google.common.net.MediaType
 import com.google.gson.Gson
 import com.freenow.apis.phraseapi.client.model.PhraseLocale
 import com.freenow.apis.phraseapi.client.model.PhraseLocales
-import feign.Response
 import org.apache.commons.httpclient.HttpStatus
 import org.junit.Test
 import org.mockito.Mockito.`when` as on
@@ -45,7 +44,7 @@ class PhraseApiClientLocaleTest {
 
         val projectsJSON = Gson().toJson(expectedLocale)
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_OK,
             "OK",
             headers,
@@ -91,7 +90,7 @@ class PhraseApiClientLocaleTest {
 
         val projectsJSON = Gson().toJson(expectedLocales)
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_OK,
             "OK",
             headers,

--- a/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientProjectTest.kt
+++ b/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientProjectTest.kt
@@ -6,7 +6,6 @@ import com.google.gson.Gson
 import com.freenow.apis.phraseapi.client.model.CreatePhraseProject
 import com.freenow.apis.phraseapi.client.model.PhraseProject
 import com.freenow.apis.phraseapi.client.model.UpdatePhraseProject
-import feign.Response
 import org.apache.commons.httpclient.HttpStatus
 import org.junit.Test
 import org.mockito.Mockito.`when` as on
@@ -41,7 +40,7 @@ class PhraseApiClientProjectTest {
             HttpHeaders.CONTENT_TYPE to listOf(MediaType.JSON_UTF_8.toString())
         )
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_OK,
             "OK",
             headers,
@@ -77,7 +76,7 @@ class PhraseApiClientProjectTest {
             HttpHeaders.CONTENT_TYPE to listOf(MediaType.JSON_UTF_8.toString())
         )
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_OK,
             "OK",
             headers,
@@ -106,7 +105,7 @@ class PhraseApiClientProjectTest {
             HttpHeaders.CONTENT_TYPE to listOf(MediaType.JSON_UTF_8.toString())
         )
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_NO_CONTENT,
             "OK",
             headers,
@@ -143,7 +142,7 @@ class PhraseApiClientProjectTest {
 
         val projectsJSON = Gson().toJson(createProjectEntity)
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_NO_CONTENT,
             "OK",
             headers,
@@ -204,7 +203,7 @@ class PhraseApiClientProjectTest {
             "name" to projectName
         ))
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_NO_CONTENT,
             "OK",
             headers,

--- a/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientTest.kt
+++ b/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientTest.kt
@@ -8,7 +8,6 @@ import com.freenow.apis.phraseapi.client.model.PhraseLocale
 import com.freenow.apis.phraseapi.client.model.PhraseLocaleMessages
 import com.freenow.apis.phraseapi.client.model.PhraseLocales
 import com.freenow.apis.phraseapi.client.model.PhraseProject
-import feign.Response
 import org.junit.Test
 import org.mockito.Mockito.`when` as on
 import org.mockito.Mockito.mock
@@ -45,7 +44,7 @@ class PhraseApiClientTest {
             "content-type" to listOf(MediaType.JSON_UTF_8.toString())
         )
 
-        val responseFirst = Response.create(
+        val responseFirst = FeignUtil.create(
             200,
             "OK",
             headers,
@@ -53,7 +52,7 @@ class PhraseApiClientTest {
             StandardCharsets.UTF_8
         )
 
-        val responseSecond = Response.create(
+        val responseSecond = FeignUtil.create(
             304,
             "OK",
             headers,
@@ -95,7 +94,7 @@ class PhraseApiClientTest {
             "content-type" to listOf(MediaType.JSON_UTF_8.toString())
         )
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             200,
             "OK",
             headers,
@@ -134,7 +133,7 @@ class PhraseApiClientTest {
             "content-type" to listOf(MediaType.JSON_UTF_8.toString())
         )
 
-        val responseFirst = Response.create(
+        val responseFirst = FeignUtil.create(
             200,
             "OK",
             headers,
@@ -142,7 +141,7 @@ class PhraseApiClientTest {
             StandardCharsets.UTF_8
         )
 
-        val responseSecond = Response.create(
+        val responseSecond = FeignUtil.create(
             304,
             "OK",
             headers,
@@ -180,7 +179,7 @@ class PhraseApiClientTest {
         val messagesString = Gson().toJson(messages)
         val headers = mapOf("content-type" to listOf(MediaType.JSON_UTF_8.toString()))
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             200,
             "OK",
             headers,
@@ -219,7 +218,7 @@ class PhraseApiClientTest {
             "content-type" to listOf(MediaType.JSON_UTF_8.toString())
         )
 
-        val responseFirst = Response.create(
+        val responseFirst = FeignUtil.create(
             200,
             "OK",
             headers,
@@ -227,7 +226,7 @@ class PhraseApiClientTest {
             StandardCharsets.UTF_8
         )
 
-        val responseSecond = Response.create(
+        val responseSecond = FeignUtil.create(
             304,
             "OK",
             headers,

--- a/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientTranslationTest.kt
+++ b/src/test/kotlin/com/freenow/apis/phraseapi/client/PhraseApiClientTranslationTest.kt
@@ -7,7 +7,6 @@ import com.freenow.apis.phraseapi.client.model.CreateTranslation
 import com.freenow.apis.phraseapi.client.model.PhraseLocale
 import com.freenow.apis.phraseapi.client.model.Translation
 import com.freenow.apis.phraseapi.client.model.TranslationKey
-import feign.Response
 import org.apache.commons.httpclient.HttpStatus
 import org.junit.Test
 import org.mockito.Mockito.`when` as on
@@ -52,7 +51,7 @@ class PhraseApiClientTranslationTest {
 
         val translationJSON = Gson().toJson(createTranslation)
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_CREATED,
             "OK",
             headers,
@@ -112,7 +111,7 @@ class PhraseApiClientTranslationTest {
 
         val translationJSON = Gson().toJson(createTranslation)
 
-        val response = Response.create(
+        val response = FeignUtil.create(
             HttpStatus.SC_CREATED,
             "OK",
             headers,


### PR DESCRIPTION
New Spring versions are now using openfeign, and opefeign has a dependency to a higher version of gson that is incompatible with older netflix.feign. This result in a library conflict while updating our service to Spring 2.7.x
The phrase-kotlin-client should update to openfeign with a recent version of gson

This fixes the following error on application startup (spring-boot 2.7.3, spring-cloud 2021.0.3, java 11):
```***************************
APPLICATION FAILED TO START
***************************

Description:

An attempt was made to call a method that does not exist. The attempt was made from the following location:

    feign.gson.DoubleToIntMapTypeAdapter.<init>(DoubleToIntMapTypeAdapter.java:43)

The following method did not exist:

    'void com.google.gson.internal.ConstructorConstructor.<init>(java.util.Map)'

The calling method's class, feign.gson.DoubleToIntMapTypeAdapter, was loaded from the following location:

    jar:file:/Users/jean-charles.robert/.m2/repository/com/netflix/feign/feign-gson/8.18.0/feign-gson-8.18.0.jar!/feign/gson/DoubleToIntMapTypeAdapter.class

The called method's class, com.google.gson.internal.ConstructorConstructor, is available from the following locations:

    jar:file:/Users/jean-charles.robert/.m2/repository/com/google/code/gson/gson/2.9.1/gson-2.9.1.jar!/com/google/gson/internal/ConstructorConstructor.class

The called method's class hierarchy was loaded from the following locations:

    com.google.gson.internal.ConstructorConstructor: file:/Users/jean-charles.robert/.m2/repository/com/google/code/gson/gson/2.9.1/gson-2.9.1.jar


Action:

Correct the classpath of your application so that it contains compatible versions of the classes feign.gson.DoubleToIntMapTypeAdapter and com.google.gson.internal.ConstructorConstructor```