### PR TITLE
Upgrade to Java 11

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     if: ${{ !startsWith(github.event.head_commit.message, '[maven-release-plugin] prepare') }}
     runs-on: ubuntu-latest
-    name: Build on Java 8
+    name: Build on Java 11
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: adopt
       - run: mvn -B verify -Dgpg.skip=true
       - name: Upload test coverage
@@ -37,10 +37,10 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
-      - name: Setup Java 1.8
+      - name: Setup Java 11
         uses: actions/setup-java@v2
         with:
-          java-version: 8
+          java-version: 11
           distribution: adopt
 
       - name: Cache Maven packages
@@ -72,5 +72,5 @@ jobs:
           gpg-key: ${{ secrets.FREE_NOW_GPG_KEY }}
           gpg-passphrase: ${{ secrets.FREE_NOW_GPG_PASSPHRASE }}
         env:
-          JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk/
+          JAVA_HOME: /usr/lib/jvm/java-11-openjdk/
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <scm.connection>scm:git:git@github.com:freenowtech/phrase-kotlin-client.git</scm.connection>
         <scm.url>https://github.com/freenowtech/phrase-kotlin-client</scm.url>
         <kotlin.version>1.7.10</kotlin.version>
@@ -242,7 +242,7 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <version>${kotlin.version}</version>
                 <configuration>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                     <args>-java-parameters</args>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <dokka.version>1.6.10</dokka.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Projects which use this library cannot be upgraded to Java 11, because generated sources cannot be placed on the class path.

> could not get default ClassPathResource. use /generated-resources/ instead 

This should point at master as soon as the other [MR](https://github.com/freenowtech/phrase-kotlin-client/pull/24) is merged.